### PR TITLE
V1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Donations help show the developer your appreciation for all their hard work. A l
     5. **Save & Exit**
 
 ####Initial Setup
-When powering on for the first time it is best to calibrate your RSSI. To do this follow these steps below. (You can repeat this process as many times as needed for best results.)
+When powering on for the first time it is best to calibrate your RSSI modules. No two modules have the same RSSI min and max readings. To calibrate follow these steps below. You can repeat this process as many times as needed.
 
-1. Power on your receiver and transmitter and place them about 10 to 20 feet apart from one another. (If you are using directional antennas make sure they are pointed at your transmitter for best results.)
+1. Power on your receiver and transmitter and place them about 5 to 20 feet apart from one another. (For best results remove antennas to calibrate each module on a level playing field.)
 2. Next navigate to the "Setup Menu".
 3. Next navigate to "Calibrate RSSI".
 4. Now that you are in the RSSI calibration screen, the receiver will scan all channels 3 times getting the min and max RSSI strength.

--- a/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
+++ b/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
@@ -96,8 +96,8 @@ uint8_t rssi = 0;
 uint8_t rssi_scaled = 0;
 uint8_t active_receiver = useReceiverA;
 #ifdef USE_DIVERSITY
-uint8_t diversity_mode = useReceiverAuto;
-char diversity_check_count = 0;
+    uint8_t diversity_mode = useReceiverAuto;
+    char diversity_check_count = 0; // used to decide when to change antennas.
 #endif
 uint8_t rssi_seek_threshold = RSSI_SEEK_TRESHOLD;
 uint8_t hight = 0;
@@ -119,20 +119,19 @@ uint8_t last_dip_channel=255;
 uint8_t last_dip_band=255;
 uint8_t scan_start=0;
 uint8_t first_tune=1;
-uint8_t force_menu_redraw=0;
+boolean force_menu_redraw=0;
 uint16_t rssi_best=0; // used for band scaner
 uint16_t rssi_min_a=0;
 uint16_t rssi_max_a=0;
 uint16_t rssi_setup_min_a=0;
 uint16_t rssi_setup_max_a=0;
 #ifdef USE_DIVERSITY
-uint16_t rssi_min_b=0;
-uint16_t rssi_max_b=0;
-uint16_t rssi_setup_min_b=0;
-uint16_t rssi_setup_max_b=0;
+    uint16_t rssi_min_b=0;
+    uint16_t rssi_max_b=0;
+    uint16_t rssi_setup_min_b=0;
+    uint16_t rssi_setup_max_b=0;
 #endif
-uint16_t rssi_seek_found=0;
-uint16_t rssi_setup_run=0;
+uint8_t rssi_setup_run=0;
 
 char call_sign[10];
 bool settings_beeps = true;
@@ -230,11 +229,6 @@ void setup()
 #endif
     force_menu_redraw=1;
 
-    // tune to first channel
-
-    // Setup Done - LED ON
-    digitalWrite(led, HIGH);
-
     // Init Display
     if (drawScreen.begin(call_sign) > 0) {
         // on Error flicker LED
@@ -250,11 +244,13 @@ void setup()
 #endif
 
 #ifdef USE_DIVERSITY
-    // make sure we use receiver A when diveristy is unplugged.
+    // make sure we use receiver Auto when diveristy is unplugged.
     if(!isDiversity()) {
-        diversity_mode = useReceiverA;
+        diversity_mode = useReceiverAuto;
     }
 #endif
+    // Setup Done - Turn Status LED off.
+    digitalWrite(led, LOW);
 
 }
 

--- a/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
+++ b/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
@@ -946,9 +946,6 @@ void wait_rssi_ready()
     // CHECK FOR MINIMUM DELAY
     // check if RSSI is stable after tune by checking the time
     uint16_t tune_time = millis()-time_of_tune;
-    // module need >20ms to tune.
-    // 25 ms will do a 40 channel scan in 1 second.
-    #define MIN_TUNE_TIME 25
     if(tune_time < MIN_TUNE_TIME)
     {
         // wait until tune time is full filled

--- a/src/rx5808-pro-diversity/settings.h
+++ b/src/rx5808-pro-diversity/settings.h
@@ -43,7 +43,12 @@ SOFTWARE.
 #define USE_DIVERSITY
 #define USE_IR_EMITTER
 //#define USE_FLIP_SCREEN
-//#define USE_BOOT_LOGO
+#define USE_BOOT_LOGO
+
+// Receiver Module version
+// used for tuning time
+#define rx5808
+//#define rx5880
 
 
 #define spiDataPin 10
@@ -119,6 +124,17 @@ SOFTWARE.
 #define CHANNEL_BAND_SIZE 8
 #define CHANNEL_MIN_INDEX 0
 #define CHANNEL_MAX_INDEX 39
+
+#ifdef rx5808
+    // rx5808 module need >20ms to tune.
+    // 25 ms will do a 40 channel scan in 1 second.
+    #define MIN_TUNE_TIME 25
+#endif
+#ifdef rx5880
+    // rx5880 module needs >30ms to tune.
+    // 35 ms will do a 40 channel scan in 1.4 seconds.
+    #define MIN_TUNE_TIME 35
+#endif
 
 #define CHANNEL_MAX 39
 #define CHANNEL_MIN 0


### PR DESCRIPTION
Updating the calibration process.
Adding some settings to select which RX module the user has.
When diversity is unplugged default to useReceiverAuto.
Turn status LED off when setup completes.