### PR TITLE
Fix compilation on unix environments

### DIFF
--- a/src/rx5808-pro-diversity/TVOut_screens.cpp
+++ b/src/rx5808-pro-diversity/TVOut_screens.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 #ifdef TVOUT_SCREENS
 #include "screens.h" // function headers
-#include <arduino.h>
+#include <Arduino.h>
 
 
 #include <TVout.h>


### PR DESCRIPTION
A filename case mismatch caused compile errors on linux. This is fixed here (at least for menu output on TV).