### PR TITLE
SH1106 support

### DIFF
--- a/src/rx5808-pro-diversity/oled_128x64_adafruit_screens.cpp
+++ b/src/rx5808-pro-diversity/oled_128x64_adafruit_screens.cpp
@@ -28,7 +28,11 @@ SOFTWARE.
 
 #ifdef OLED_128x64_ADAFRUIT_SCREENS
 #include "screens.h" // function headers
-#include <Adafruit_SSD1306.h>
+#ifdef SH1106
+	#include <Adafruit_SH1106.h>
+#else
+	#include <Adafruit_SSD1306.h>
+#endif
 #include <Adafruit_GFX.h>
 #include <Wire.h>
 #include <SPI.h>
@@ -41,11 +45,18 @@ char *PSTRtoBuffer_P(PGM_P str) { uint8_t c='\0', i=0; for(; (c = pgm_read_byte(
 
 #define INVERT INVERSE
 #define OLED_RESET 4
-Adafruit_SSD1306 display(OLED_RESET);
-
-#if !defined SSD1306_128_64
-    #error("Screen size incorrect, please fix Adafruit_SSD1306.h!");
+#ifdef SH1106
+	Adafruit_SH1106 display(OLED_RESET);
+	#if !defined SH1106_128_64
+		#error("Screen size incorrect, please fix Adafruit_SH1106.h!");
+	#endif
+#else
+	Adafruit_SSD1306 display(OLED_RESET);
+	#if !defined SSD1306_128_64
+		#error("Screen size incorrect, please fix Adafruit_SSD1306.h!");
+	#endif
 #endif
+
 
 screens::screens() {
     last_channel = -1;
@@ -55,7 +66,13 @@ screens::screens() {
 char screens::begin(const char *call_sign) {
     // Set the address of your OLED Display.
     // 128x64 ONLY!!
+#ifdef SH1106
+    display.begin(SH1106_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3D or 0x3C (for the 128x64)
+#else
     display.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3D or 0x3C (for the 128x64)
+#endif
+
+
 #ifdef USE_FLIP_SCREEN
     flip();
 #endif

--- a/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
+++ b/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
@@ -44,7 +44,12 @@ SOFTWARE.
 //    #include <fontALL.h>
 #endif
 #ifdef OLED_128x64_ADAFRUIT_SCREENS
-    #include <Adafruit_SSD1306.h>
+
+	#ifdef SH1106
+		#include <Adafruit_SH1106.h>
+	#else
+		#include <Adafruit_SSD1306.h>
+	#endif
     #include <Adafruit_GFX.h>
     #include <Wire.h>
     #include <SPI.h>

--- a/src/rx5808-pro-diversity/settings.h
+++ b/src/rx5808-pro-diversity/settings.h
@@ -33,7 +33,7 @@ SOFTWARE.
 #define OLED_128x64_ADAFRUIT_SCREENS
 
 // use the library from https://github.com/badzz/Adafruit_SH1106 before enabling
-//#define SH1106
+#define SH1106
 
 // u8glib has performance issues.
 //#define OLED_128x64_U8G_SCREENS

--- a/src/rx5808-pro-diversity/settings.h
+++ b/src/rx5808-pro-diversity/settings.h
@@ -32,6 +32,9 @@ SOFTWARE.
 //#define TVOUT_SCREENS
 #define OLED_128x64_ADAFRUIT_SCREENS
 
+// use the library from https://github.com/badzz/Adafruit_SH1106 before enabling
+//#define SH1106
+
 // u8glib has performance issues.
 //#define OLED_128x64_U8G_SCREENS
 


### PR DESCRIPTION
Some oled drivers are not real SSD1306 but actually SH1106 that do not support vertical/horizontal adressing. I modified the adafruit lib https://github.com/badzz/Adafruit_SH1106 that you can use by uncommenting
//#define SH1106
in settings.h