### PR TITLE
SH1106 support

### DIFF
--- a/docs/diy-custom-board.md
+++ b/docs/diy-custom-board.md
@@ -13,9 +13,9 @@ No bootloader is nessissary with this board. Program the board using the SPI bre
 - 2x Blue LEDs 0805 [Mouser](http://www.mouser.com/Search/ProductDetail.aspx?R=LTST-C170KRKTvirtualkey57820000virtualkey859-LTST-C170KRKT)
 - 1x Red LED 0805 [Mouser](http://www.mouser.com/Search/ProductDetail.aspx?R=LTST-C170TBKTvirtualkey57820000virtualkey859-LTST-C170TBKT)
 - 1x [Navigation switch](https://www.sparkfun.com/products/8184) or [ebay](http://www.ebay.com/itm/231618098407?ul_noapp=true)
-- 2x SMA Connector [Mouser](http://www.mouser.com/Search/ProductDetail.aspx?R=132289virtualkey52330000virtualkey523-132289)
+- 2x SMA Connector [Mouser](http://www.mouser.com/search/ProductDetail.aspx?R=0virtualkey0virtualkey132322)
 - 1x 4066D SO14 digital switch chip SMD [Mouser](http://www.mouser.com/Search/ProductDetail.aspx?R=74LVC4066D%2c118virtualkey66800000virtualkey771-74LVC4066D-T)
-- 1x MEGA 328 TQFP [Mouser](http://www.mouser.com/Search/ProductDetail.aspx?R=ATMEGA328-AUvirtualkey55660000virtualkey556-ATMEGA328-AU)
+- 1x MEGA 328P TQFP [Mouser](http://www.mouser.com/search/ProductDetail.aspx?R=0virtualkey0virtualkeyATMEGA328P-AU)
 - 1x Active Buzzer (Optional)
 - 1x OLED 128x64 display I2C (5v tollerant) (Optional - If you don't want to do TV_Out)
 

--- a/src/rx5808-pro-diversity/oled_128x64_adafruit_screens.cpp
+++ b/src/rx5808-pro-diversity/oled_128x64_adafruit_screens.cpp
@@ -28,7 +28,11 @@ SOFTWARE.
 
 #ifdef OLED_128x64_ADAFRUIT_SCREENS
 #include "screens.h" // function headers
-#include <Adafruit_SSD1306.h>
+#ifdef SH1106
+	#include <Adafruit_SH1106.h>
+#else
+	#include <Adafruit_SSD1306.h>
+#endif
 #include <Adafruit_GFX.h>
 #include <Wire.h>
 #include <SPI.h>
@@ -41,11 +45,18 @@ char *PSTRtoBuffer_P(PGM_P str) { uint8_t c='\0', i=0; for(; (c = pgm_read_byte(
 
 #define INVERT INVERSE
 #define OLED_RESET 4
-Adafruit_SSD1306 display(OLED_RESET);
-
-#if !defined SSD1306_128_64
-    #error("Screen size incorrect, please fix Adafruit_SSD1306.h!");
+#ifdef SH1106
+	Adafruit_SH1106 display(OLED_RESET);
+	#if !defined SH1106_128_64
+		#error("Screen size incorrect, please fix Adafruit_SH1106.h!");
+	#endif
+#else
+	Adafruit_SSD1306 display(OLED_RESET);
+	#if !defined SSD1306_128_64
+		#error("Screen size incorrect, please fix Adafruit_SSD1306.h!");
+	#endif
 #endif
+
 
 screens::screens() {
     last_channel = -1;
@@ -55,7 +66,13 @@ screens::screens() {
 char screens::begin(const char *call_sign) {
     // Set the address of your OLED Display.
     // 128x64 ONLY!!
+#ifdef SH1106
+    display.begin(SH1106_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3D or 0x3C (for the 128x64)
+#else
     display.begin(SSD1306_SWITCHCAPVCC, 0x3C);  // initialize with the I2C addr 0x3D or 0x3C (for the 128x64)
+#endif
+
+
 #ifdef USE_FLIP_SCREEN
     flip();
 #endif

--- a/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
+++ b/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
@@ -44,7 +44,12 @@ SOFTWARE.
 //    #include <fontALL.h>
 #endif
 #ifdef OLED_128x64_ADAFRUIT_SCREENS
-    #include <Adafruit_SSD1306.h>
+
+	#ifdef SH1106
+		#include <Adafruit_SH1106.h>
+	#else
+		#include <Adafruit_SSD1306.h>
+	#endif
     #include <Adafruit_GFX.h>
     #include <Wire.h>
     #include <SPI.h>

--- a/src/rx5808-pro-diversity/settings.h
+++ b/src/rx5808-pro-diversity/settings.h
@@ -32,6 +32,9 @@ SOFTWARE.
 //#define TVOUT_SCREENS
 #define OLED_128x64_ADAFRUIT_SCREENS
 
+// use the library from https://github.com/badzz/Adafruit_SH1106 before enabling
+//#define SH1106
+
 // u8glib has performance issues.
 //#define OLED_128x64_U8G_SCREENS
 


### PR DESCRIPTION
Some oled drivers are not real SSD1306 but actually SH1106 that do not support vertical/horizontal adressing. I modified the adafruit lib https://github.com/badzz/Adafruit_SH1106 that you can use by uncommenting
//#define SH1106
in settings.h