### PR TITLE
When USE_DIVERSITY is disabled when menu_id==3 back up two menu slots

### DIFF
--- a/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
+++ b/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
@@ -396,6 +396,10 @@ void loop()
                     if(!isDiversity() && menu_id == 3) { // make sure we back up two menu slots.
                         menu_id--;
                     }
+#else 
+                    if(menu_id == 3) { // as we dont use diveristy make sure we back up two menu slots.
+                        menu_id--;
+                    }
 #endif
                 }
                 else if(digitalRead(buttonDown) == LOW) {


### PR DESCRIPTION
Hey,
this is a small fix for receivers that don't use diversity - it worked traveling down the menu (skiped diversity) but didn't work when traveling up the menu.

The other option to is to define isDiversity() to return always false when USE_DIVERSITY isnt defined.
