### PR TITLE
Add battery voltage on main TVOut screen

### DIFF
--- a/src/rx5808-pro-diversity/TVOut_screens.cpp
+++ b/src/rx5808-pro-diversity/TVOut_screens.cpp
@@ -134,6 +134,10 @@ void screens::seekMode(uint8_t state) {
     TV.select_font(font4x6);
     TV.printPGM(5,TV_Y_OFFSET+4*TV_Y_GRID,  PSTR("RSSI:"));
     TV.draw_line(0,5*TV_Y_GRID-4,TV_X_MAX,5*TV_Y_GRID-4,WHITE);
+#ifdef USE_VOLTAGE_MONITORING
+    TV.draw_line(86,4*TV_Y_GRID,86,5*TV_Y_GRID-4,WHITE);
+    TV.printPGM(90, TV_Y_OFFSET+4*TV_Y_GRID, PSTR("VBAT: "));
+#endif
     // frame for tune graph
     TV.draw_rect(0,TV_ROWS - TV_SCANNER_OFFSET,TV_X_MAX,13,  WHITE); // lower frame
 #ifdef USE_LBAND
@@ -146,7 +150,7 @@ void screens::seekMode(uint8_t state) {
 
 }
 
-void screens::updateSeekMode(uint8_t state, uint8_t channelIndex, uint8_t channel, uint8_t rssi, uint16_t channelFrequency, uint8_t rssi_seek_threshold, bool locked) {
+void screens::updateSeekMode(uint8_t state, uint8_t channelIndex, uint8_t channel, uint8_t rssi, uint16_t channelFrequency, uint8_t rssi_seek_threshold, bool locked,uint16_t voltage) {
     // display refresh handler
     TV.select_font(font8x8);
     if(channelIndex != last_channel) // only updated on changes
@@ -201,9 +205,23 @@ void screens::updateSeekMode(uint8_t state, uint8_t channelIndex, uint8_t channe
         // show frequence
         TV.print(50,TV_Y_OFFSET+3*TV_Y_GRID, channelFrequency);
     }
-    // show signal strength
+    
+#ifdef USE_VOLTAGE_MONITORING
+    //show voltage
+    TV.select_font(font4x6);
+    TV.print(110, TV_Y_OFFSET+4*TV_Y_GRID, (float)voltage/10, 1);
+    TV.select_font(font8x8);
+#endif
+
+   
+#ifdef USE_VOLTAGE_MONITORING
+    #define RSSI_BAR_SIZE 58
+#else
     #define RSSI_BAR_SIZE 100
-    uint8_t rssi_scaled=map(rssi, 1, 100, 1, RSSI_BAR_SIZE);
+#endif
+    
+    // show signal strength 
+    uint8_t rssi_scaled=map(rssi, 1, 100, 1, RSSI_BAR_SIZE);    
     // clear last bar
     TV.draw_rect(25, TV_Y_OFFSET+4*TV_Y_GRID, RSSI_BAR_SIZE,4 , BLACK, BLACK);
     //  draw new bar

--- a/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
+++ b/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
@@ -40,8 +40,8 @@ SOFTWARE.
 // uncomment depending on the display you are using.
 // this is an issue with the arduino preprocessor
 #ifdef TVOUT_SCREENS
-//    #include <TVout.h>
-//    #include <fontALL.h>
+//   #include <TVout.h>
+//   #include <fontALL.h>
 #endif
 #ifdef OLED_128x64_ADAFRUIT_SCREENS
 
@@ -856,7 +856,7 @@ void loop()
             state = STATE_SCREEN_SAVER;
         }
 #endif
-        drawScreen.updateSeekMode(state, channelIndex, channel, rssi, pgm_read_word_near(channelFreqTable + channelIndex), rssi_seek_threshold, seek_found);
+        drawScreen.updateSeekMode(state, channelIndex, channel, rssi, pgm_read_word_near(channelFreqTable + channelIndex), rssi_seek_threshold, seek_found, voltage);
     }
     /****************************/
     /*   Processing SCAN MODE   */

--- a/src/rx5808-pro-diversity/screens.h
+++ b/src/rx5808-pro-diversity/screens.h
@@ -57,7 +57,7 @@ class screens
 
         // SEEK & MANUAL MODE
         void seekMode(uint8_t state); // seek and manual mode
-        void updateSeekMode(uint8_t state, uint8_t channelIndex, uint8_t channel, uint8_t rssi, uint16_t channelFrequency, uint8_t rssi_seek_threshold, bool locked); // seek and manual mode
+        void updateSeekMode(uint8_t state, uint8_t channelIndex, uint8_t channel, uint8_t rssi, uint16_t channelFrequency, uint8_t rssi_seek_threshold, bool locked,uint16_t votlage); // seek and manual mode
 
         // BAND SCAN
         void bandScanMode(uint8_t state);


### PR DESCRIPTION
There was no way to see battery voltage on main screen with TV out - there is now.
https://cloud.githubusercontent.com/assets/878316/25547439/705b617e-2c67-11e7-9a13-23617ce585ab.JPG
