### PR TITLE
Swap RSSI graphs to match hardware

### DIFF
--- a/src/rx5808-pro-diversity/state_search_ui.cpp
+++ b/src/rx5808-pro-diversity/state_search_ui.cpp
@@ -147,7 +147,7 @@ void StateMachine::SearchStateHandler::drawScanBar() {
 void StateMachine::SearchStateHandler::drawRssiGraph() {
     #ifdef USE_DIVERSITY
         Ui::drawGraph(
-            Receiver::rssiALast,
+            Receiver::rssiBLast,
             RECEIVER_LAST_DATA_SIZE,
             100,
             GRAPH_X,
@@ -157,7 +157,7 @@ void StateMachine::SearchStateHandler::drawRssiGraph() {
         );
 
         Ui::drawGraph(
-            Receiver::rssiBLast,
+            Receiver::rssiALast,
             RECEIVER_LAST_DATA_SIZE,
             100,
             GRAPH_X,
@@ -177,10 +177,10 @@ void StateMachine::SearchStateHandler::drawRssiGraph() {
         display.setTextColor(INVERSE);
 
         display.setCursor(RX_TEXT_X, RX_TEXT_A_Y);
-        display.print(PSTR2("A"));
+        display.print(PSTR2("B"));
 
         display.setCursor(RX_TEXT_X, RX_TEXT_B_Y);
-        display.print(PSTR2("B"));
+        display.print(PSTR2("A"));
     #else
         Ui::drawGraph(
             Receiver::rssiALast,


### PR DESCRIPTION
Thanks @Knifa for spot me to the right piece of code. This will swap RSSI graph of both modules to match the hardware inputs on the combined module.
![img_20170515_190955](https://cloud.githubusercontent.com/assets/1228155/26070437/f1556eec-39a4-11e7-81e3-d8cc7af766c0.jpg)
