### PR TITLE
Disable Screensaver for Bandscan

### DIFF
--- a/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
+++ b/src/rx5808-pro-diversity/rx5808-pro-diversity.ino
@@ -127,6 +127,7 @@ void loop() {
 
     if (
         StateMachine::currentState != StateMachine::State::SCREENSAVER
+        && StateMachine::currentState != StateMachine::State::BANDSCAN
         && (millis() - Buttons::lastChangeTime) >
             (SCREENSAVER_TIMEOUT * 1000)
     ) {


### PR DESCRIPTION
Hey !

I used the band scan today for testing. I found that the screensaver is annoying in this mode while I'm working with quads.

What do you think ?