### PR TITLE
Only require a single click to enter the search sidebar menu

### DIFF
--- a/src/rx5808-pro-diversity/ui_state_menu.cpp
+++ b/src/rx5808-pro-diversity/ui_state_menu.cpp
@@ -31,16 +31,16 @@ bool StateMenuHelper::handleButtons(
     Button button,
     Buttons::PressType pressType
 ) {
-    if (button == Button::MODE && pressType == Buttons::PressType::LONG) {
-        this->visible = !this->visible;
-        if (!this->visible)
+    if (button == Button::MODE) {
+        if (this->visible && pressType == Buttons::PressType::LONG) {
+            this->visible = false;
             Ui::needFullRedraw();
-
-        if (this->visible) {
+            return true;
+        } else if (!this->visible && pressType == Buttons::PressType::SHORT) {
+            this->visible = true;
             this->slideX = MENU_W;
+            return true;
         }
-
-        return true;
     }
 
     if (!this->isVisible())


### PR DESCRIPTION
I feels fairly unnatural to need to long press to enter the sidebar menu on the search screen.

This only requires a single press to do so, which is more consistent with the operation of the main menu.