### PR TITLE
Add missing include for SH1106 OLED

### DIFF
--- a/src/rx5808-pro-diversity/ui.h
+++ b/src/rx5808-pro-diversity/ui.h
@@ -3,6 +3,7 @@
 
 
 #include <Adafruit_SSD1306.h>
+#include <Adafruit_SH1106.h>
 #include <stdint.h>
 
 #include "settings.h"


### PR DESCRIPTION
Adding missing include header for the OLED SH1106.